### PR TITLE
Add gpu support for evaluate to enhance module

### DIFF
--- a/denoiser/enhance.py
+++ b/denoiser/enhance.py
@@ -56,6 +56,9 @@ group.add_argument("--noisy_json", type=str, default=None,
 
 def get_estimate(model, noisy, args):
     torch.set_num_threads(1)
+    device = next(iter(model.parameters())).device
+
+    noisy = noisy.to(device)
     if args.streaming:
         streamer = DemucsStreamer(model, dry=args.dry)
         with torch.no_grad():
@@ -105,6 +108,9 @@ def enhance(args, model=None, local_out_dir=None):
     # Load model
     if not model:
         model = pretrained.get_model(args).to(args.device)
+    if torch.cuda.is_available():
+        model = model.cuda()
+
     model.eval()
     if local_out_dir:
         out_dir = local_out_dir


### PR DESCRIPTION
I'm using this tool to preprocess noisy audios for training TTS models. And I need a use case where I can process gigabytes of audios. On CPU it takes so much time. I'm added GPU support to enhance the inference module. That's boosted my code 26 times.