### PR TITLE
fix: init `conv_state` and `lstm_state` when calling `flush` method

### DIFF
--- a/denoiser/demucs.py
+++ b/denoiser/demucs.py
@@ -279,7 +279,7 @@ class DemucsStreamer:
         pending_length = self.pending.shape[1]
         padding = th.zeros(self.demucs.chin, self.total_length, device=self.pending.device)
         out = self.feed(padding)
-        self.
+        self.conv_state = None
         return out[:, :pending_length]
 
     def feed(self, wav):

--- a/denoiser/demucs.py
+++ b/denoiser/demucs.py
@@ -279,6 +279,7 @@ class DemucsStreamer:
         pending_length = self.pending.shape[1]
         padding = th.zeros(self.demucs.chin, self.total_length, device=self.pending.device)
         out = self.feed(padding)
+        self.
         return out[:, :pending_length]
 
     def feed(self, wav):

--- a/denoiser/demucs.py
+++ b/denoiser/demucs.py
@@ -273,8 +273,9 @@ class DemucsStreamer:
 
     def flush(self):
         """
-        Flush remaining audio by padding it with zero. Call this
-        when you have no more input and want to get back the last chunk of audio.
+        Flush remaining audio by padding it with zero and initialize the previous
+        status. Call this when you have no more input and want to get back the last
+        chunk of audio.
         """
         pending_length = self.pending.shape[1]
         padding = th.zeros(self.demucs.chin, self.total_length, device=self.pending.device)

--- a/denoiser/demucs.py
+++ b/denoiser/demucs.py
@@ -277,10 +277,11 @@ class DemucsStreamer:
         status. Call this when you have no more input and want to get back the last
         chunk of audio.
         """
+        self.lstm_state = None
+        self.conv_state = None
         pending_length = self.pending.shape[1]
         padding = th.zeros(self.demucs.chin, self.total_length, device=self.pending.device)
         out = self.feed(padding)
-        self.conv_state = None
         return out[:, :pending_length]
 
     def feed(self, wav):


### PR DESCRIPTION
fix: init `conv_state` when calling `flush` method

Resolves #137